### PR TITLE
Disable documentation previews

### DIFF
--- a/.github/workflows/CleanPreview.yml
+++ b/.github/workflows/CleanPreview.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   doc-preview-cleanup:
+    if: false                        # disable this workflow (change if `push_preview=true` in make.jl)
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,5 +27,5 @@ makedocs(;
 deploydocs(;
     repo="github.com/timholy/ThickNumbers.jl",
     devbranch="main",
-    push_preview=true,
+    push_preview=false,      # see also the corresponding flag in .github/workflows/CleanPreview.yml
 )


### PR DESCRIPTION
While this now deletes old previews when the PR closes,
presumably they still add to the git history and thus
the size of the repo. This disables them for now.