### PR TITLE
Fix ForwardDiff v1 compatibility in ForwardDiff extension

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,26 +20,28 @@ jobs:
       matrix:
         version:
           - '1'
-          - '1.9'
+          - 'min'
         os:
           - ubuntu-latest
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - name: InterfaceTests
         run: julia --project=ThickNumbersInterfaceTests -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.test(coverage="all")'
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
   docs:
     name: Documentation
     runs-on: ubuntu-latest
@@ -47,8 +49,8 @@ jobs:
       contents: write
       statuses: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1'
       - name: Configure doc environment

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ThickNumbers"
 uuid = "b57aa878-5b76-4266-befc-f8e007760995"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ThickNumbers"
 uuid = "b57aa878-5b76-4266-befc-f8e007760995"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
-version = "1.0.1"
+version = "1.1.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -16,7 +16,7 @@ ThickNumbersForwardDiffExt = "ForwardDiff"
 DifferentiationInterface = "0.6"
 ForwardDiff = "0.10, 1"
 LinearAlgebra = "1"
-julia = "1.9"
+julia = "1.10"
 
 [extras]
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"

--- a/ext/ThickNumbersForwardDiffExt.jl
+++ b/ext/ThickNumbersForwardDiffExt.jl
@@ -29,6 +29,18 @@ function Base.:*(partials::Partials, x::ThickNumber)
     return Partials(ForwardDiff.scale_tuple(partials.values, x))
 end
 
+# ForwardDiff v1's `scale_tuple`/`mul_tuples`/`div_tuple_by_scalar` dispatch
+# elementwise through `_mul_partial`/`_div_partial`, which only ship `Real`-`Real`
+# methods; the partial tuple elements and/or the deriv/factor arguments may be
+# ThickNumber here (e.g. at higher derivative orders), so every ThickNumber/Real
+# combination needs a method.
+ForwardDiff._mul_partial(partial::Real, x::ThickNumber) = partial * x
+ForwardDiff._mul_partial(partial::ThickNumber, x::Real) = partial * x
+ForwardDiff._mul_partial(partial::ThickNumber, x::ThickNumber) = partial * x
+ForwardDiff._div_partial(partial::Real, x::ThickNumber) = partial / x
+ForwardDiff._div_partial(partial::ThickNumber, x::Real) = partial / x
+ForwardDiff._div_partial(partial::ThickNumber, x::ThickNumber) = partial / x
+
 Base.promote_rule(::Type{TN}, ::Type{Dual{T,V,N}}) where {TN<:ThickNumber,T,V<:Number,N} = Dual{T, promote_dual(TN, V),N}
 
 promote_dual(::Type{TN}, ::Type{V}) where {TN<:ThickNumber,V} = promote_type(TN, V)


### PR DESCRIPTION
ForwardDiff v1 dispatches Partials scaling and division through internal _mul_partial/_div_partial helpers that only ship Real-Real methods. Higher derivative orders route ThickNumber-valued arguments through them (partial tuple elements and/or the deriv/factor operand), so every ThickNumber/Real combination needs its own method.